### PR TITLE
Add new feature: allowed_values attribute to field types

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -4,7 +4,7 @@
 
 1. Update the version in `envmodel/version.py`.
 
-3. Run the release script:
+2. Run the release script:
 
     ```bash
     ./scripts/release.sh

--- a/docs/source/fields.md
+++ b/docs/source/fields.md
@@ -12,6 +12,7 @@ A string field that can hold any string value.
 * `name`: The name of the environment variable.
 * `required`: Whether the environment variable is required. Defaults to `False`.
 * `default`: The default value of the environment variable. Defaults to `None`.
+* `allowed_values`: A list of allowed values for the environment variable.
 * `error`: The error message to display if the environment variable is not set. Defaults to a generic error message.
 
 #### Example
@@ -46,26 +47,28 @@ class MyConfig(EnvModel):
 ### FloatField
 
 A float field that can hold any float value.
-   
+
 #### Options
 
 * `name`: The name of the environment variable.
-* `required`: Whether the environment variable is required. Defaults to False.
-* `default`: The default value of the environment variable. Defaults to None.
+* `required`: Whether the environment variable is required. Defaults to `False`.
+* `default`: The default value of the environment variable. Defaults to `None`.
 * `error`: The error message to display if the environment variable is not set. Defaults to a generic error message.
- 
+
 #### Example
 
 ```python
 from envmodel import EnvModel, FloatField
 
-class MyConfig(EnvModel): 
-    timeout = FloatField(name="TIMEOUT", default=30.0)
+class MyConfig(EnvModel):
+    temperature = FloatField(name="TEMPERATURE", required=False, default=20.0)
 ```
+
+In this example, `temperature` will default to 20.0 if not set in the environment.
 
 ### BooleanField
 
-A boolean field that can hold a boolean value.
+A boolean field that can hold True or False values.
 
 #### Options
 

--- a/envmodel/fields.py
+++ b/envmodel/fields.py
@@ -10,6 +10,7 @@ class BaseField:
         name: str,
         required: bool = False,
         default: str | None = None,
+        allowed_values: list | None = None,
         error: str | None = None,
         lazy: bool = True,
         warning: str | None = None,
@@ -17,6 +18,7 @@ class BaseField:
         self.name = name
         self.required = required
         self.default: Any = default
+        self.allowed_values = allowed_values
         self.error = f"Environment variable {name} is required" if error is None else error
         self.lazy = lazy
         self.warning = warning
@@ -31,6 +33,8 @@ class BaseField:
 
     def __call__(self) -> str:
         env_value = self.get_env_variable()
+        if self.allowed_values and env_value not in self.allowed_values:
+            raise Exception(f"Environment variable {self.name} must be one of {self.allowed_values}")
         if self.required and env_value is None:
             raise Exception(self.error)
         if self.warning and env_value is None:

--- a/tests/fields/basefield_test.py
+++ b/tests/fields/basefield_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from envmodel import BaseField
 
 
@@ -47,4 +49,20 @@ class BaseFieldTest:
             field()
 
         expected_error = f"Environment variable {var_name} is required"
+        assert str(excinfo.value) == expected_error
+
+    # add a test for the allowed values
+    def test_allowed_values(self, monkeypatch):
+        # Arrange
+        allowed_values = ["value1", "value2"]
+        field = BaseField(name="TEST_VAR", allowed_values=allowed_values)
+
+        # Ensure the environment variable is set to a value not in the allowed values
+        monkeypatch.setenv("TEST_VAR", "not_allowed")
+
+        # Act & Assert
+        with pytest.raises(Exception) as excinfo:
+            field()
+
+        expected_error = f"Environment variable TEST_VAR must be one of {allowed_values}"
         assert str(excinfo.value) == expected_error


### PR DESCRIPTION
This pull request introduces a new feature to the EnvModel library by adding the allowed_values attribute to the field types. This enhancement allows users to specify a list of acceptable values for environment variables, improving validation and usability.